### PR TITLE
Changed the version of datascope

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tensorflow_hub
 tensorflow_datasets
 pyyaml
 torch
-datascope==0.0.3
+datascope==0.0.8
 torch
 pyarrow
 tqdm


### PR DESCRIPTION
Problem: Version of Datascope was 0.0.3 which was causing errors in the the execution of the following commands

`mlcube run --task=create_baselines -Pdocker.build_strategy=always`

Error message:

```
Traceback (most recent call last):
  File "/app/create_baselines.py", line 9, in <module>
    from baselines.datascope_wrapper import ShapleyAppraiser
  File "/app/baselines/datascope_wrapper.py", line 4, in <module>
    from datascope.importance.shapley import ShapleyImportance, ImportanceMethod
  File "/usr/local/lib/python3.9/site-packages/datascope/importance/shapley.py", line 24, in <module>
    from .shapley_cy import compute_all_importances_cy
  File "datascope/importance/shapley_cy.pyx", line 11, in init datascope.importance.shapley_cy
  File "/usr/local/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```


 Solution: Changing to the latest datascope releases fixes the issue.